### PR TITLE
Fix missing langchain_community module

### DIFF
--- a/email_producer/requirements.txt
+++ b/email_producer/requirements.txt
@@ -1,3 +1,4 @@
 langchain
+langchain-community
 kafka-python
 openai

--- a/responder/requirements.txt
+++ b/responder/requirements.txt
@@ -1,4 +1,5 @@
 fastapi
 uvicorn
 langchain
+langchain-community
 langsmith

--- a/supervisor/requirements.txt
+++ b/supervisor/requirements.txt
@@ -1,4 +1,5 @@
 langchain
+langchain-community
 langgraph
 langsmith
 kafka-python


### PR DESCRIPTION
## Summary
- fix `ModuleNotFoundError` by adding `langchain-community` to every requirements file

## Testing
- `pytest -q`