### PR TITLE
Add Kafka demo with producer and consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,32 @@ The example domain is food deliveries, where customers complain about their deli
 The multi agents should only communicate over the network using MCP where appropriate.
 ```
 
+
+## Running the demo
+
+The demo uses `docker-compose` to start a single Kafka broker in KRaft mode and two Python workers. One worker continuously produces dummy customer emails to the `incoming-messages` topic. The second worker consumes those messages and writes a simple reply to the `outgoing-messages` topic.
+
+### Prerequisites
+
+- Docker and docker-compose installed
+
+### Steps
+
+1. Start the environment:
+
+   ```bash
+   docker-compose up
+   ```
+
+   This will pull the required images, start Kafka, create the two topics and run both workers.
+
+2. You should see the producer outputting messages once per second and the consumer printing the generated responses.
+
+3. Stop the demo with `Ctrl+C` and remove the containers with:
+
+   ```bash
+   docker-compose down
+   ```
+
+
+

--- a/consumer/consumer.py
+++ b/consumer/consumer.py
@@ -1,0 +1,38 @@
+import json
+from kafka import KafkaConsumer, KafkaProducer
+from datetime import datetime
+import uuid
+
+def main() -> None:
+    consumer = KafkaConsumer(
+        "incoming-messages",
+        bootstrap_servers="kafka:9092",
+        value_deserializer=lambda v: json.loads(v.decode("utf-8")),
+        auto_offset_reset="earliest",
+        enable_auto_commit=True,
+    )
+
+    producer = KafkaProducer(
+        bootstrap_servers="kafka:9092",
+        value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+    )
+
+    for msg in consumer:
+        incoming = msg.value
+        print("Received", incoming)
+        response = {
+            "id": str(uuid.uuid4()),
+            "from": incoming.get("to", "support@example.com"),
+            "to": incoming.get("from", "customer@example.com"),
+            "subject": f"Re: {incoming.get('subject', '')}",
+            "body": "Thank you for contacting us. We will look into your issue.",
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+        producer.send("outgoing-messages", response)
+        producer.flush()
+        print("Sent response", response)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+version: "3.8"
+services:
+  kafka:
+    image: bitnami/kafka:3.5
+    container_name: kafka
+    environment:
+      - KAFKA_CFG_NODE_ID=1
+      - KAFKA_CFG_PROCESS_ROLES=broker,controller
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@kafka:9093
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - ALLOW_PLAINTEXT_LISTENER=yes
+    ports:
+      - "9092:9092"
+    volumes:
+      - kafka_data:/bitnami/kafka
+
+  topic-init:
+    image: bitnami/kafka:3.5
+    depends_on:
+      - kafka
+    entrypoint: ["/scripts/create-topics.sh"]
+    volumes:
+      - ./scripts/create-topics.sh:/scripts/create-topics.sh:ro
+
+  producer:
+    image: python:3.11-slim
+    depends_on:
+      - kafka
+      - topic-init
+    volumes:
+      - ./producer:/app
+      - ./requirements.txt:/requirements.txt:ro
+    working_dir: /app
+    command: bash -c "pip install -r /requirements.txt && python producer.py"
+
+  consumer:
+    image: python:3.11-slim
+    depends_on:
+      - kafka
+      - topic-init
+    volumes:
+      - ./consumer:/app
+      - ./requirements.txt:/requirements.txt:ro
+    working_dir: /app
+    command: bash -c "pip install -r /requirements.txt && python consumer.py"
+
+volumes:
+  kafka_data:
+

--- a/producer/producer.py
+++ b/producer/producer.py
@@ -1,0 +1,30 @@
+import json
+import time
+import uuid
+from datetime import datetime
+from kafka import KafkaProducer
+
+def main() -> None:
+    producer = KafkaProducer(
+        bootstrap_servers="kafka:9092",
+        value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+    )
+
+    while True:
+        message = {
+            "id": str(uuid.uuid4()),
+            "from": "customer@example.com",
+            "to": "support@example.com",
+            "subject": "Order issue",
+            "body": "My order was wrong, please fix it.",
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+        producer.send("incoming-messages", message)
+        producer.flush()
+        print("Produced message", message)
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+kafka-python

--- a/scripts/create-topics.sh
+++ b/scripts/create-topics.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+# Wait for Kafka broker to be ready
+sleep 5
+
+/opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic incoming-messages --partitions 1 --replication-factor 1
+/opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic outgoing-messages --partitions 1 --replication-factor 1
+


### PR DESCRIPTION
## Summary
- add docker-compose config to run Kafka in KRaft mode
- add scripts and Python workers to produce and consume messages
- create requirements.txt with kafka-python
- document how to run the demo in README
- refine python workers and setup script for reliability

## Testing
- `python -m py_compile producer/producer.py consumer/consumer.py`
- ❌ `docker compose version` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683b4cb596e0832b9217c7244487ba9b