### PR TITLE
Fix Kafka startup race condition

### DIFF
--- a/consumer/consumer.py
+++ b/consumer/consumer.py
@@ -1,21 +1,50 @@
 import json
+import time
 from kafka import KafkaConsumer, KafkaProducer
+from kafka.errors import NoBrokersAvailable
 from datetime import datetime
 import uuid
 
-def main() -> None:
-    consumer = KafkaConsumer(
-        "incoming-messages",
-        bootstrap_servers="kafka:9092",
-        value_deserializer=lambda v: json.loads(v.decode("utf-8")),
-        auto_offset_reset="earliest",
-        enable_auto_commit=True,
-    )
 
-    producer = KafkaProducer(
-        bootstrap_servers="kafka:9092",
-        value_serializer=lambda v: json.dumps(v).encode("utf-8"),
-    )
+def create_consumer(max_retries: int = 10, delay: int = 5) -> KafkaConsumer:
+    """Create a Kafka consumer with retry logic."""
+    attempt = 0
+    while True:
+        try:
+            return KafkaConsumer(
+                "incoming-messages",
+                bootstrap_servers="kafka:9092",
+                value_deserializer=lambda v: json.loads(v.decode("utf-8")),
+                auto_offset_reset="earliest",
+                enable_auto_commit=True,
+            )
+        except NoBrokersAvailable:
+            attempt += 1
+            if attempt >= max_retries:
+                raise
+            print(f"Kafka broker not available, retrying in {delay}s ({attempt}/{max_retries})")
+            time.sleep(delay)
+
+
+def create_producer(max_retries: int = 10, delay: int = 5) -> KafkaProducer:
+    """Create a Kafka producer with retry logic."""
+    attempt = 0
+    while True:
+        try:
+            return KafkaProducer(
+                bootstrap_servers="kafka:9092",
+                value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+            )
+        except NoBrokersAvailable:
+            attempt += 1
+            if attempt >= max_retries:
+                raise
+            print(f"Kafka broker not available, retrying in {delay}s ({attempt}/{max_retries})")
+            time.sleep(delay)
+
+def main() -> None:
+    consumer = create_consumer()
+    producer = create_producer()
 
     for msg in consumer:
         incoming = msg.value

--- a/producer/producer.py
+++ b/producer/producer.py
@@ -3,12 +3,27 @@ import time
 import uuid
 from datetime import datetime
 from kafka import KafkaProducer
+from kafka.errors import NoBrokersAvailable
+
+
+def create_producer(max_retries: int = 10, delay: int = 5) -> KafkaProducer:
+    """Create a Kafka producer with simple retry logic."""
+    attempt = 0
+    while True:
+        try:
+            return KafkaProducer(
+                bootstrap_servers="kafka:9092",
+                value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+            )
+        except NoBrokersAvailable:
+            attempt += 1
+            if attempt >= max_retries:
+                raise
+            print(f"Kafka broker not available, retrying in {delay}s ({attempt}/{max_retries})")
+            time.sleep(delay)
 
 def main() -> None:
-    producer = KafkaProducer(
-        bootstrap_servers="kafka:9092",
-        value_serializer=lambda v: json.dumps(v).encode("utf-8"),
-    )
+    producer = create_producer()
 
     while True:
         message = {


### PR DESCRIPTION
## Summary
- add connection retry logic for Kafka producer and consumer

## Testing
- `python -m py_compile producer/producer.py consumer/consumer.py`


------
https://chatgpt.com/codex/tasks/task_e_683b52ac25a4832ba3273986047ce181