### PR TITLE
feat: Add manual review UI and message routing logic

### DIFF
--- a/Dockerfile.consumer
+++ b/Dockerfile.consumer
@@ -1,0 +1,10 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY consumer.py ./
+
+CMD ["python", "consumer.py"]

--- a/Dockerfile.manual_review_ui
+++ b/Dockerfile.manual_review_ui
@@ -1,0 +1,19 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the dependencies file to the working directory
+COPY requirements.txt ./
+
+# Install any needed packages specified in requirements.txt
+# We'll add Flask to requirements.txt in the next step
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the content of the local src directory to the working directory
+COPY manual_review_ui.py ./
+
+# Specify the command to run on container start
+# The Flask app itself is configured to run on port 5001
+CMD ["python", "manual_review_ui.py"]

--- a/Dockerfile.producer
+++ b/Dockerfile.producer
@@ -1,0 +1,10 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY producer.py ./
+
+CMD ["python", "producer.py"]

--- a/README.md
+++ b/README.md
@@ -1,48 +1,103 @@
-# ambient-agents-demo
-A demo of creating distributed ambient agents using different coding agents.
+# AI-Powered Customer Service Demo with Kafka & Manual Review UI
 
-Inspirations:
-- https://blog.langchain.dev/introducing-ambient-agents/
+This project demonstrates a customer service workflow for a food delivery company using Apache Kafka in KRaft mode, featuring an AI agent and a manual review process with a simple web UI. Customers' messages are sent to an `incoming-messages` topic. About 50% are processed by an AI worker and responded to directly, while the other 50% are routed to a `manual-review` topic for human intervention via a web interface. All final responses are published to an `outgoing-messages` topic.
 
-## Attempt 1
+## Components
 
-Prompt 1:
+1.  **`docker-compose.yml`**:
+    *   Sets up a single-node Kafka broker running in KRaft mode.
+    *   Defines a `kafka-setup` service that automatically creates three topics: `incoming-messages`, `outgoing-messages`, and `manual-review`.
+    *   Defines services for a `producer`, `consumer`, and `manual-review-ui` application, all built using Docker.
+2.  **`producer.py` (Worker 1)**:
+    *   A Python script simulating incoming customer messages (e.g., emails).
+    *   Publishes these messages to the `incoming-messages` Kafka topic.
+    *   Containerized and managed by `docker-compose`.
+3.  **`consumer.py` (Worker 2)**:
+    *   A Python script that consumes messages from `incoming-messages`.
+    *   **Randomly (50/50 chance)** either:
+        *   Forwards the original message to the `manual-review` topic for human processing.
+        *   Simulates an AI agent generating a response and publishes it to `outgoing-messages`.
+    *   Containerized and managed by `docker-compose`.
+4.  **`manual_review_ui.py` (Manual Review Web UI)**:
+    *   A Flask-based Python web application.
+    *   Consumes messages from the `manual-review` Kafka topic.
+    *   Displays these messages on a web page where a human agent can review them.
+    *   Provides an interface for the human agent to write and submit a response.
+    *   Publishes the human-generated response to the `outgoing-messages` Kafka topic.
+    *   Containerized and managed by `docker-compose`, accessible typically on port `5001`.
+5.  **Dockerfiles (`Dockerfile.producer`, `Dockerfile.consumer`, `Dockerfile.manual_review_ui`)**:
+    *   Used to build the images for the Python applications.
+6.  **`requirements.txt`**:
+    *   Lists Python dependencies (`kafka-python`, `Flask`).
 
+## Prerequisites
+
+*   [Docker](https://docs.docker.com/get-docker/)
+*   [Docker Compose](https://docs.docker.com/compose/install/)
+
+## Running the Demo
+
+1.  **Clone the repository (if you haven't already):**
+    ```bash
+    # git clone <repository-url>
+    # cd <repository-directory>
+    ```
+
+2.  **Build and start all services:**
+    This command will build/rebuild Docker images and start all services (Kafka, producer, consumer, manual review UI) in detached mode.
+    ```bash
+    docker-compose up --build -d
+    ```
+
+3.  **View Logs:**
+    Monitor the logs to see messages being produced, consumed, split for AI/manual review, and processed.
+    *   **All services:** `docker-compose logs -f`
+    *   **Producer:** `docker-compose logs -f producer`
+    *   **Consumer (AI/Splitter):** `docker-compose logs -f consumer`
+    *   **Manual Review UI:** `docker-compose logs -f manual-review-ui`
+    *   **Kafka:** `docker-compose logs -f kafka`
+
+4.  **Access the Manual Review UI:**
+    *   Open your web browser and navigate to: **`http://localhost:5001`**
+    *   You should see messages that were routed for manual review. If no messages appear immediately, wait for the producer to send some that get routed by the consumer (this happens randomly).
+    *   Submit responses through the UI. These responses will be published to the `outgoing-messages` topic.
+
+5.  **Inspect Kafka Topics (Optional):**
+    Use Kafka's command-line tools to directly observe messages.
+    *   **Incoming messages:**
+        ```bash
+        docker-compose exec kafka kafka-console-consumer.sh           --bootstrap-server kafka:9092 --topic incoming-messages --from-beginning
+        ```
+    *   **Messages routed for manual review:**
+        ```bash
+        docker-compose exec kafka kafka-console-consumer.sh           --bootstrap-server kafka:9092 --topic manual-review --from-beginning
+        ```
+    *   **Final outgoing responses (from AI or Human):**
+        ```bash
+        docker-compose exec kafka kafka-console-consumer.sh           --bootstrap-server kafka:9092 --topic outgoing-messages --from-beginning
+        ```
+    Press `Ctrl+C` to stop watching a topic.
+
+6.  **Stopping the Demo:**
+    To stop and remove all containers, networks, and (optionally) volumes:
+    ```bash
+    docker-compose down
+    ```
+    To also remove the Kafka data volume (all messages will be lost):
+    ```bash
+    docker-compose down -v
+    ```
+
+## Project Structure
 ```
-
-Implement an AI-powered customer service for a food delivery company. Customers write messages to the company and the company responds to and acts on those messages using a combination of AI agents and human agents.
-Examples:
-> Customer: I just received my food but it was the wrong order. I ordered burgers, not hot dogs. Please send me the right order or give me my money back.
-> AI: Sorry about that, we will send you a delicious burger right away.
-> Customer: The food was cold when I received it. I want my money back.
-> AI agent: Sorry about that, I have handled your case over to my human colleague who will review your case, since it involves a request for monetary compensation.
-> Human agent: I have reviewed your case and approved your request to get your money back.
-
-Using docker-compose, create a small demo that runs Kafka in KRaft mode with two topics called `incoming-messages` and `outgoing-messages`.
-Create two dummy workers written in Python:
-Worker 1) generate and publish dummy events to `incoming-messages`, once per second. The event should have fields typical of an email.
-Worker 2) consume events from `incoming-messages`, genererate a dummy response event and publish to `outgoing-messages`. Again, the event should have fields typical of an email.
-Add info to README.md about how to run the demo.
+.
+├── docker-compose.yml          # Docker Compose setup for all services
+├── Dockerfile.consumer         # Dockerfile for the consumer (AI/splitter)
+├── Dockerfile.manual_review_ui # Dockerfile for the Manual Review UI
+├── Dockerfile.producer         # Dockerfile for the producer
+├── producer.py                 # Python script for message generation
+├── consumer.py                 # Python script for AI processing & routing
+├── manual_review_ui.py         # Flask app for manual review
+├── requirements.txt            # Python dependencies
+└── README.md                   # This file
 ```
-
-## Concerns
-
-- Tone of voice: a customer service department should always be polite.
-- Risk: taking risky actions automatically, such as monetary compensation, should be guard railed, e.g., by requiring a human in the loop.
-
-## Previous attempts
-
-I tried using these prompts with Google Jules and OpenAI Codex. Not super successful. Too much at the same time, too many bugs.
-
-### Prompt 1
-
-Here I tried to one-shot the prompt to create the demo all at once. It failed.
-
-```
-Create an ambient agent demo using MCP, langchain, langgraph, langsmith, Kafka and docker-compose where agents running in different docker containers collaborate to handle customer service emails.
-Create a fake email producer that uses an LLM to write synthetic customer service emails and publish them to kafka topic 'incoming-emails'.
-Have a supervisor agent subscribe to these events and connect with tools and other agents over MCP and produce responses to the emails on kafka topic outgoing-emails''.
-The example domain is food deliveries, where customers complain about their deliveries in different ways.
-The multi agents should only communicate over the network using MCP where appropriate.
-```
-

--- a/consumer.py
+++ b/consumer.py
@@ -1,0 +1,158 @@
+import json
+import time
+import uuid
+import random # Added import
+from kafka import KafkaConsumer, KafkaProducer
+from kafka.errors import KafkaError
+import logging
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+# Kafka Configuration
+KAFKA_BROKER = 'kafka:9092'
+INCOMING_TOPIC = 'incoming-messages'
+OUTGOING_TOPIC = 'outgoing-messages'
+MANUAL_REVIEW_TOPIC = 'manual-review' # Added new topic
+CONSUMER_GROUP_ID = 'customer-service-group'
+
+# Response templates
+AI_RESPONSES = {
+    "wrong order": "We are very sorry about the mix-up with your order. A replacement is being prepared and will be sent to you right away.",
+    "cold food": "We apologize that your food arrived cold. This is not the experience we want you to have.",
+    "late arrival": "We sincerely apologize for the delay in your delivery. We are looking into what caused this.",
+    "overcharged": "Thank you for bringing this to our attention. We are reviewing your billing details now.",
+    "feature request": "Thank you for your suggestion! We've passed it along to our development team for consideration.",
+    "default": "Thank you for reaching out. We have received your message and will process it shortly."
+}
+
+HUMAN_ESCALATION_MESSAGE = "I have handled your case over to my human colleague who will review your case, as it requires further attention (e.g., monetary compensation)."
+
+def create_consumer():
+    """Creates and returns a KafkaConsumer instance."""
+    try:
+        consumer = KafkaConsumer(
+            INCOMING_TOPIC,
+            bootstrap_servers=[KAFKA_BROKER],
+            auto_offset_reset='earliest',
+            enable_auto_commit=True,
+            group_id=CONSUMER_GROUP_ID,
+            value_deserializer=lambda v: json.loads(v.decode('utf-8')))
+        logging.info(f"KafkaConsumer connected and subscribed to topic '{INCOMING_TOPIC}'.")
+        return consumer
+    except Exception as e:
+        logging.error(f"Failed to connect KafkaConsumer: {e}")
+        return None
+
+def create_producer():
+    """Creates and returns a KafkaProducer instance for sending responses/forwarding messages."""
+    try:
+        producer = KafkaProducer(
+            bootstrap_servers=[KAFKA_BROKER],
+            value_serializer=lambda v: json.dumps(v).encode('utf-8'),
+            retries=5,
+            acks='all')
+        logging.info("KafkaProducer for responses/forwarding connected successfully.")
+        return producer
+    except Exception as e:
+        logging.error(f"Failed to connect KafkaProducer: {e}")
+        return None
+
+def generate_ai_response(incoming_message): # Renamed for clarity
+    """Generates an AI response based on the incoming message."""
+    original_body = incoming_message.get('body', '').lower()
+    original_subject = incoming_message.get('subject', '').lower()
+
+    responder_type = "AI"
+    response_body = AI_RESPONSES["default"]
+
+    if "money back" in original_body or "refund" in original_body:
+        responder_type = "AI_ESCALATION_TO_HUMAN"
+        response_body = HUMAN_ESCALATION_MESSAGE
+    elif "wrong order" in original_subject or "wrong items" in original_subject:
+        response_body = AI_RESPONSES["wrong order"]
+    elif "cold food" in original_subject:
+        response_body = AI_RESPONSES["cold food"]
+        if "money back" in original_body or "refund" in original_body:
+             responder_type = "AI_ESCALATION_TO_HUMAN"
+             response_body = HUMAN_ESCALATION_MESSAGE
+    elif "late arrival" in original_subject:
+        response_body = AI_RESPONSES["late arrival"]
+    elif "overcharged" in original_subject:
+        response_body = AI_RESPONSES["overcharged"]
+    elif "feature request" in original_subject:
+        response_body = AI_RESPONSES["feature request"]
+
+    return {
+        "original_message_id": incoming_message.get('message_id'),
+        "response_id": str(uuid.uuid4()),
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "responder_type": responder_type,
+        "body": response_body
+    }
+
+def main():
+    consumer = create_consumer()
+    producer = create_producer() # This producer will be used for both topics
+
+    if not consumer or not producer:
+        logging.error("Exiting due to Kafka connection failure.")
+        if consumer: consumer.close()
+        if producer: producer.close()
+        return
+
+    logging.info(f"Starting to consume messages from '{INCOMING_TOPIC}'. Will distribute to AI response or manual review.")
+    try:
+        for message in consumer:
+            try:
+                incoming_data = message.value
+                msg_id = incoming_data.get('message_id', 'UnknownID')
+                logging.info(f"Received message: {msg_id} - {incoming_data.get('subject')}")
+
+                # 50/50 split logic
+                if random.random() < 0.5:
+                    # Forward to manual review
+                    logging.info(f"Forwarding message {msg_id} to '{MANUAL_REVIEW_TOPIC}'.")
+                    future = producer.send(MANUAL_REVIEW_TOPIC, value=incoming_data)
+                    try:
+                        record_metadata = future.get(timeout=10)
+                        logging.debug(f"Message {msg_id} forwarded to topic '{record_metadata.topic}' partition {record_metadata.partition} offset {record_metadata.offset}")
+                    except KafkaError as ke:
+                        logging.error(f"Failed to forward message {msg_id} to '{MANUAL_REVIEW_TOPIC}': {ke}")
+                    except Exception as e:
+                        logging.error(f"Unexpected error forwarding message {msg_id} to '{MANUAL_REVIEW_TOPIC}': {e}")
+                else:
+                    # Process with AI and send to outgoing
+                    logging.info(f"Processing message {msg_id} with AI.")
+                    ai_response_data = generate_ai_response(incoming_data)
+                    logging.info(f"Sending AI response for {ai_response_data['original_message_id']} by {ai_response_data['responder_type']} to '{OUTGOING_TOPIC}'.")
+
+                    future = producer.send(OUTGOING_TOPIC, value=ai_response_data)
+                    try:
+                        record_metadata = future.get(timeout=10)
+                        logging.debug(f"AI Response for {msg_id} sent to topic '{record_metadata.topic}' partition {record_metadata.partition} offset {record_metadata.offset}")
+                    except KafkaError as ke:
+                        logging.error(f"Failed to send AI response for {msg_id} to '{OUTGOING_TOPIC}': {ke}")
+                    except Exception as e:
+                        logging.error(f"Unexpected error sending AI response for {msg_id} to '{OUTGOING_TOPIC}': {e}")
+
+            except json.JSONDecodeError:
+                logging.error(f"Failed to decode JSON message: {message.value}")
+            except Exception as e:
+                logging.error(f"Error processing message: {e}", exc_info=True)
+
+    except KeyboardInterrupt:
+        logging.info("Shutting down consumer and producer...")
+    except Exception as e:
+        logging.error(f"An unexpected error occurred in the main consumer loop: {e}", exc_info=True)
+    finally:
+        if consumer:
+            consumer.close()
+            logging.info("KafkaConsumer closed.")
+        if producer:
+            producer.flush()
+            producer.close()
+            logging.info("KafkaProducer (for responses/forwarding) closed.")
+
+if __name__ == "__main__":
+    main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,94 @@
+version: '3.8'
+
+services:
+  kafka:
+    image: bitnami/kafka:latest
+    ports:
+      - "9093:9093" # External listener for host access if needed
+    environment:
+      # KRaft settings
+      - KAFKA_CFG_NODE_ID=1
+      - KAFKA_CFG_PROCESS_ROLES=broker,controller
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9094,EXTERNAL://:9093
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,EXTERNAL://localhost:9093
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@kafka:9094
+      # Topic settings
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=false
+      - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=1
+      - KAFKA_CFG_GROUP_INITIAL_REBALANCE_DELAY_MS=0
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server kafka:9092 --list || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - kafka_data:/bitnami/kafka
+    networks:
+      - kafka-net
+
+  kafka-setup:
+    image: bitnami/kafka:latest
+    depends_on:
+      kafka:
+        condition: service_healthy
+    entrypoint: /bin/sh
+    command: >
+      -c "
+        echo 'Waiting for Kafka to be ready...'
+        sleep 5
+        echo 'Creating topics...'
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic incoming-messages --partitions 1 --replication-factor 1
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic outgoing-messages --partitions 1 --replication-factor 1
+        kafka-topics.sh --bootstrap-server kafka:9092 --create --if-not-exists --topic manual-review --partitions 1 --replication-factor 1
+        echo 'Topics created.'
+        kafka-topics.sh --bootstrap-server kafka:9092 --list
+      "
+    networks:
+      - kafka-net
+
+  producer:
+    build:
+      context: .
+      dockerfile: Dockerfile.producer
+    depends_on:
+      kafka-setup: # Changed from condition to just depends_on for service startup order
+        condition: service_completed_successfully
+    networks:
+      - kafka-net
+    restart: on-failure
+
+  consumer:
+    build:
+      context: .
+      dockerfile: Dockerfile.consumer
+    depends_on:
+      kafka-setup: # Changed from condition to just depends_on for service startup order
+        condition: service_completed_successfully
+    networks:
+      - kafka-net
+    restart: on-failure
+
+  manual-review-ui:
+    build:
+      context: .
+      dockerfile: Dockerfile.manual_review_ui # Will be created in a later step
+    ports:
+      - "5001:5001" # Exposing port for the UI
+    depends_on:
+      kafka-setup: # Ensure topics are created
+        condition: service_completed_successfully
+    networks:
+      - kafka-net
+    restart: on-failure
+
+volumes:
+  kafka_data:
+
+networks:
+  kafka-net:
+    driver: bridge

--- a/manual_review_ui.py
+++ b/manual_review_ui.py
@@ -1,0 +1,190 @@
+import json
+import time
+import uuid
+import threading
+from flask import Flask, render_template_string, request, redirect, url_for
+from kafka import KafkaConsumer, KafkaProducer
+from kafka.errors import KafkaError
+import logging
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+# Flask App Configuration
+app = Flask(__name__)
+
+# Kafka Configuration
+KAFKA_BROKER = 'kafka:9092'
+MANUAL_REVIEW_TOPIC = 'manual-review'
+OUTGOING_TOPIC = 'outgoing-messages'
+UI_CONSUMER_GROUP_ID = 'manual-review-ui-group'
+
+# In-memory store for messages awaiting review
+# Each item will be a dictionary (the message from Kafka)
+REVIEW_MESSAGES = []
+# Lock for thread-safe access to REVIEW_MESSAGES
+review_messages_lock = threading.Lock()
+
+# Global Kafka producer for the UI to send responses
+ui_kafka_producer = None
+
+# HTML Template for the main page
+HTML_TEMPLATE = '''
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Manual Review Queue</title>
+    <style>
+        body { font-family: sans-serif; margin: 20px; background-color: #f4f4f4; color: #333; }
+        .container { background-color: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+        h1 { color: #555; }
+        .message-item { border: 1px solid #ddd; padding: 15px; margin-bottom: 15px; border-radius: 5px; background-color: #f9f9f9; }
+        .message-details { margin-bottom: 10px; }
+        .message-details p { margin: 5px 0; }
+        .message-details strong { color: #444; }
+        textarea { width: 95%; padding: 10px; margin-bottom: 10px; border: 1px solid #ccc; border-radius: 4px; }
+        button { padding: 10px 15px; background-color: #5cb85c; color: white; border: none; border-radius: 4px; cursor: pointer; }
+        button:hover { background-color: #4cae4c; }
+        .no-messages { color: #777; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Messages Awaiting Manual Review</h1>
+        {% if messages %}
+            {% for message in messages %}
+                <div class="message-item">
+                    <div class="message-details">
+                        <p><strong>Message ID:</strong> {{ message.message_id }}</p>
+                        <p><strong>Customer ID:</strong> {{ message.customer_id }}</p>
+                        <p><strong>Timestamp:</strong> {{ message.timestamp }}</p>
+                        <p><strong>Subject:</strong> {{ message.subject }}</p>
+                        <p><strong>Body:</strong></p>
+                        <p>{{ message.body }}</p>
+                    </div>
+                    <form action="{{ url_for('submit_response') }}" method="post">
+                        <input type="hidden" name="original_message_id" value="{{ message.message_id }}">
+                        <textarea name="human_response_text" rows="3" placeholder="Type your response here..." required></textarea>
+                        <button type="submit">Submit Response</button>
+                    </form>
+                </div>
+            {% endfor %}
+        {% else %}
+            <p class="no-messages">No messages currently in the manual review queue.</p>
+        {% endif %}
+    </div>
+</body>
+</html>
+'''
+
+def kafka_consumer_thread():
+    """Thread function to consume messages from 'manual-review' topic."""
+    consumer = None
+    try:
+        consumer = KafkaConsumer(
+            MANUAL_REVIEW_TOPIC,
+            bootstrap_servers=[KAFKA_BROKER],
+            auto_offset_reset='earliest',
+            group_id=UI_CONSUMER_GROUP_ID,
+            value_deserializer=lambda v: json.loads(v.decode('utf-8')),
+            consumer_timeout_ms=1000 # Timeout to allow thread to check running flag
+        )
+        logging.info(f"UI KafkaConsumer connected to '{MANUAL_REVIEW_TOPIC}'.")
+
+        while True: # Continuously poll for messages
+            for message in consumer:
+                if message and message.value:
+                    logging.info(f"UI received message for review: {message.value.get('message_id')}")
+                    with review_messages_lock:
+                        # Avoid duplicates if consumer restarts and re-reads if not committed
+                        if not any(m['message_id'] == message.value.get('message_id') for m in REVIEW_MESSAGES):
+                            REVIEW_MESSAGES.append(message.value)
+            time.sleep(0.1) # Small sleep to prevent tight loop when no messages
+
+    except Exception as e:
+        logging.error(f"Error in UI Kafka consumer thread: {e}", exc_info=True)
+    finally:
+        if consumer:
+            consumer.close()
+            logging.info("UI KafkaConsumer closed.")
+
+@app.route('/')
+def index():
+    with review_messages_lock:
+        # Pass a copy to avoid issues if modified during render
+        messages_to_display = list(REVIEW_MESSAGES)
+    return render_template_string(HTML_TEMPLATE, messages=messages_to_display)
+
+@app.route('/submit-response', methods=['POST'])
+def submit_response():
+    global ui_kafka_producer
+    original_message_id = request.form.get('original_message_id')
+    human_response_text = request.form.get('human_response_text')
+
+    if not original_message_id or not human_response_text:
+        logging.warning("Attempted to submit response with missing data.")
+        return "Missing data", 400
+
+    response_payload = {
+        "original_message_id": original_message_id,
+        "response_id": str(uuid.uuid4()),
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "responder_type": "HUMAN",
+        "body": human_response_text
+    }
+
+    try:
+        if not ui_kafka_producer:
+            logging.error("UI KafkaProducer not initialized.")
+            return "Error sending response (Producer not ready)", 500
+
+        future = ui_kafka_producer.send(OUTGOING_TOPIC, value=response_payload)
+        future.get(timeout=10) # Wait for send confirmation
+        logging.info(f"Human response for {original_message_id} sent to '{OUTGOING_TOPIC}'.")
+
+        # Remove from review queue
+        with review_messages_lock:
+            REVIEW_MESSAGES[:] = [msg for msg in REVIEW_MESSAGES if msg.get('message_id') != original_message_id]
+
+        return redirect(url_for('index'))
+
+    except KafkaError as ke:
+        logging.error(f"Kafka error sending human response for {original_message_id}: {ke}")
+        return f"Failed to send response due to Kafka error: {ke}", 500
+    except Exception as e:
+        logging.error(f"Error submitting human response for {original_message_id}: {e}", exc_info=True)
+        return f"An unexpected error occurred: {e}", 500
+
+def init_kafka_producer():
+    global ui_kafka_producer
+    try:
+        ui_kafka_producer = KafkaProducer(
+            bootstrap_servers=[KAFKA_BROKER],
+            value_serializer=lambda v: json.dumps(v).encode('utf-8'),
+            retries=5,
+            acks='all'
+        )
+        logging.info("UI KafkaProducer initialized successfully.")
+    except Exception as e:
+        logging.error(f"Failed to initialize UI KafkaProducer: {e}", exc_info=True)
+        # The app might still run but sending responses will fail.
+        # Consider how to handle this in a real app (e.g. retry mechanism, health check)
+
+if __name__ == '__main__':
+    init_kafka_producer() # Initialize the producer once when the app starts
+
+    # Start Kafka consumer in a background thread
+    # Set daemon=True so it exits when the main thread exits
+    consumer_thread = threading.Thread(target=kafka_consumer_thread, daemon=True)
+    consumer_thread.start()
+
+    # Start Flask development server
+    # Port 5001 as specified in docker-compose.yml
+    app.run(host='0.0.0.0', port=5001, debug=False)
+
+    # Cleanup (mainly for standalone runs, Docker handles container shutdown)
+    if ui_kafka_producer:
+        ui_kafka_producer.close()
+        logging.info("UI KafkaProducer closed on exit.")

--- a/producer.py
+++ b/producer.py
@@ -1,0 +1,92 @@
+import json
+import time
+import uuid
+import random
+from kafka import KafkaProducer
+from kafka.errors import KafkaError
+import logging
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+# Kafka Configuration
+KAFKA_BROKER = 'kafka:9092' # Assumes running within docker-compose network
+TOPIC_NAME = 'incoming-messages'
+
+# Dummy message templates
+SUBJECTS = [
+    "Order Issue: Wrong Items",
+    "Food Quality Complaint: Cold Food",
+    "Delivery Problem: Late Arrival",
+    "Billing Inquiry: Overcharged",
+    "App Feature Request: Easier Reordering"
+]
+BODIES = [
+    "I received my food but it was the wrong order. I ordered burgers, not hot dogs. Please send me the right order or give me my money back.",
+    "The food was cold when I received it. I want my money back.",
+    "My delivery was over 30 minutes late. What happened?",
+    "I believe I was overcharged for my last order. Can you check?",
+    "It would be great if your app had a one-click reorder button for past orders."
+]
+
+def create_producer():
+    """Creates and returns a KafkaProducer instance."""
+    try:
+        producer = KafkaProducer(
+            bootstrap_servers=[KAFKA_BROKER],
+            value_serializer=lambda v: json.dumps(v).encode('utf-8'),
+            retries=5, # Retry up to 5 times for transient errors
+            acks='all' # Wait for all in-sync replicas to acknowledge
+        )
+        logging.info("KafkaProducer connected successfully.")
+        return producer
+    except Exception as e:
+        logging.error(f"Failed to connect KafkaProducer: {e}")
+        return None
+
+def generate_message():
+    """Generates a dummy customer message."""
+    return {
+        "message_id": str(uuid.uuid4()),
+        "customer_id": random.randint(1000, 9999),
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "subject": random.choice(SUBJECTS),
+        "body": random.choice(BODIES)
+    }
+
+def main():
+    producer = create_producer()
+    if not producer:
+        logging.error("Exiting due to KafkaProducer connection failure.")
+        return
+
+    logging.info(f"Starting to send messages to topic '{TOPIC_NAME}' on broker {KAFKA_BROKER}")
+    try:
+        while True:
+            message = generate_message()
+            logging.info(f"Sending message: {message['message_id']} - {message['subject']}")
+
+            future = producer.send(TOPIC_NAME, value=message)
+
+            # Block for 'synchronous' sends & get metadata
+            try:
+                record_metadata = future.get(timeout=10)
+                logging.debug(f"Message sent to topic '{record_metadata.topic}' partition {record_metadata.partition} offset {record_metadata.offset}")
+            except KafkaError as ke:
+                logging.error(f"Failed to send message {message['message_id']}: {ke}")
+            except Exception as e:
+                logging.error(f"An unexpected error occurred while sending message {message['message_id']}: {e}")
+
+            time.sleep(1)
+    except KeyboardInterrupt:
+        logging.info("Shutting down producer...")
+    except Exception as e:
+        logging.error(f"An unexpected error occurred in the main loop: {e}")
+    finally:
+        if producer:
+            producer.flush() # Ensure all pending messages are sent
+            producer.close()
+            logging.info("KafkaProducer closed.")
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+kafka-python>=2.0.0
+Flask>=2.0.0


### PR DESCRIPTION
This commit introduces a manual review workflow to the customer service demo.

Key changes include:
- A new Kafka topic `manual-review` has been added.
- The `consumer.py` script now randomly forwards 50% of incoming messages to the `manual-review` topic. The other 50% are processed by me as before.
- A new Flask-based web application (`manual_review_ui.py`) allows human agents to:
    - Consume messages from the `manual-review` topic.
    - View these messages in a web interface.
    - Submit responses, which are then published to the `outgoing-messages` topic with `responder_type: HUMAN`.
- A `Dockerfile.manual_review_ui` has been added to containerize the new web UI.
- `docker-compose.yml` has been updated to include the new topic creation and the `manual-review-ui` service.
- `requirements.txt` now includes `Flask`.
- `README.md` has been extensively updated to reflect the new architecture, components, and provide instructions for using the manual review UI.