### PR TITLE
Fix: Prevent BuildError for commented-out route in template

### DIFF
--- a/email_client_ui.py
+++ b/email_client_ui.py
@@ -217,7 +217,7 @@ HTML_LAYOUT = """
     // Auto-refresh received messages section every 5 seconds
     // This is a simple polling mechanism. For production, WebSockets or Server-Sent Events are better.
     // setInterval(function() {
-    //    // fetch("{{ url_for('get_received_messages_data') }}")
+    //    {# // fetch("{{ url_for('get_received_messages_data') }}") #}
     //        .then(response => response.json())
     //        .then(data => {
     //            const container = document.getElementById('received-messages-container');


### PR DESCRIPTION
The application was raising a `werkzeug.routing.exceptions.BuildError` because a `url_for('get_received_messages_data')` call within the `HTML_LAYOUT` template string was being processed by Jinja2. This occurred even though the line was commented out with JavaScript comments (`//`), as Jinja2 still parses such lines. The corresponding Flask route (`get_received_messages_data`) was also commented out in the Python code, leading to the error.

This commit fixes the issue by changing the comment for the `url_for` call in the template from JavaScript style (`//`) to Jinja2 style (`{# ... #}`). This ensures Jinja2 ignores the call, preventing the BuildError, while keeping the polling feature disabled as intended.